### PR TITLE
Add release automation and documentation

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,95 @@
+name: build-and-create-release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    paths-ignore:
+      - ".github/**"
+      - ".gitignore"
+      - "README.md"
+      - "LICENSE"
+      - "CHANGELOG.md"
+      - "docs/**"
+      - "gitversion.yml"
+      - ".editorconfig"
+      - ".vs/**"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v3.2.0
+      with:
+        versionSpec: '6.2.0'
+
+    - name: Get version
+      uses: gittools/actions/gitversion/execute@v3.2.0
+      id: get_version
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Publish Win x64 exe
+      run: dotnet publish src/AskLlm/AskLlm.csproj -c Release --os win --arch x64 -p:Version=${{ steps.get_version.outputs.MajorMinorPatch }}
+
+    - name: Publish Linux x64 binary
+      run: dotnet publish src/AskLlm/AskLlm.csproj -c Release --os linux --arch x64 -p:Version=${{ steps.get_version.outputs.MajorMinorPatch }}
+
+    - name: Upload Win build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-x64-build-v${{ steps.get_version.outputs.MajorMinorPatch }}
+        path: '**/bin/Release/net*/win-x64/publish/askllm.exe'
+        if-no-files-found: error
+
+    - name: Upload Linux build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-x64-build-v${{ steps.get_version.outputs.MajorMinorPatch }}
+        path: '**/bin/Release/net*/linux-x64/publish/askllm'
+        if-no-files-found: error
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: v${{ steps.get_version.outputs.MajorMinorPatch }}
+        name: Release v${{ steps.get_version.outputs.MajorMinorPatch }}
+        generate_release_notes: true
+        draft: false
+        prerelease: false
+        make_latest: true
+        files: |
+            **/bin/Release/net*/win-x64/publish/askllm.exe
+            **/bin/Release/net*/linux-x64/publish/askllm
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - id: scoop-file-update
+      name: scoop file version update
+      shell: pwsh
+      run: |
+        ./updatescoop.ps1 -Version ${{ steps.get_version.outputs.MajorMinorPatch }}
+
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      name: Commit new scoop file
+      with:
+        commit_message: Update scoop file to version ${{ steps.get_version.outputs.MajorMinorPatch }}
+        file_pattern: ask-llm.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
 # ask-llm
-Ask any LLM a question via your terminal.
+Ask any large language model from your terminal using an OpenAI-compatible API. The app is a .NET 9 console application that uses Spectre.Console to provide a friendly command-line experience.
+
+## Download
+
+[![GitHub Release](https://img.shields.io/github/v/release/yetanotherchris/ask-llm?logo=github&sort=semver)](https://github.com/yetanotherchris/ask-llm/releases/latest)
+
+You can download the latest version of ask-llm using PowerShell or Bash:
+
+```powershell
+Invoke-WebRequest -Uri "https://github.com/yetanotherchris/ask-llm/releases/latest/download/askllm.exe" -OutFile "askllm.exe"
+```
+```bash
+wget -O askllm "https://github.com/yetanotherchris/ask-llm/releases/latest/download/askllm"
+chmod +x askllm
+```
+```bash
+curl -L "https://github.com/yetanotherchris/ask-llm/releases/latest/download/askllm" -o askllm
+chmod +x askllm
+```
+
+Scoop.sh on Windows:
+```powershell
+scoop bucket add ask-llm https://github.com/yetanotherchris/ask-llm
+scoop install ask-llm
+```
+
+You can also download the latest release directly from the [Releases page](https://github.com/yetanotherchris/ask-llm/releases).
+
+## Configuration
+
+ask-llm reads its configuration from environment variables:
+
+- `ASKLLM_API_KEY` (required): API key used to authenticate with your OpenAI-compatible endpoint.
+- `ASKLLM_API_ENDPOINT` (optional): Override the default endpoint (`https://openrouter.ai/api/v1`).
+
+### Setting environment variables
+
+PowerShell:
+```powershell
+$env:ASKLLM_API_KEY = "sk-..."
+$env:ASKLLM_API_ENDPOINT = "https://your-endpoint.example/v1" # optional
+```
+
+Bash:
+```bash
+export ASKLLM_API_KEY="sk-..."
+export ASKLLM_API_ENDPOINT="https://your-endpoint.example/v1" # optional
+```
+
+## Usage
+
+```
+USAGE:
+    askllm --model <model_name> "<query>"
+
+OPTIONS:
+    -m, --model <model_name>    The model identifier to send the request to (required)
+    -h, --help                  Show command help
+```
+
+### Examples
+
+```powershell
+askllm.exe --model "x-ai/grok-4-fast:free" "Write a haiku about dotnet"
+```
+```bash
+./askllm --model gpt-4o-mini "Translate 'How are you?' to French"
+askllm --model gpt-4o-mini "Summarise the latest commit"
+```
+
+If you clone the source (requires [.NET 9](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) preview or later):
+
+```bash
+dotnet restore
+dotnet run --project src/AskLlm/AskLlm.csproj -- --model gpt-4o-mini "Hello there"
+```
+
+## Development
+
+```bash
+dotnet build
+dotnet test
+```
+
+## License
+
+ask-llm is licensed under the [MIT License](LICENSE).

--- a/ask-llm.json
+++ b/ask-llm.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.1.0",
+  "architecture": {
+      "64bit": {
+          "url": "https://github.com/yetanotherchris/ask-llm/releases/download/v0.1.0/askllm.exe",
+          "bin": [
+              "askllm.exe"
+          ],
+          "hash": "EB38736AA11A65506B11D1204FE9F628955885C411C450626C0501B70AA617CD"
+      }
+  },
+  "homepage": "https://github.com/yetanotherchris/ask-llm",
+  "license": "MIT License",
+  "description": "Ask any large language model from your terminal via OpenAI-compatible APIs."
+}

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,0 +1,4 @@
+branches:
+  # Use the Git tag for releases, e.g. v1.2.3 (it needs to be in Major.Minor.Patch format)
+  main:
+    increment: None

--- a/src/AskLlm/AskLlm.csproj
+++ b/src/AskLlm/AskLlm.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AssemblyName>askllm</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/updatescoop.ps1
+++ b/updatescoop.ps1
@@ -1,0 +1,39 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Version
+)
+
+$searchRoot = Join-Path -Path $PSScriptRoot -ChildPath 'src/AskLlm/bin/Release'
+if (-not (Test-Path -Path $searchRoot)) {
+    throw "Publish output not found at $searchRoot"
+}
+
+$searchPattern = "*publish/askllm.exe"
+$askLlmFile = Get-ChildItem -Path $searchRoot -Force -Recurse -File | Where-Object { $_.FullName -like $searchPattern } | Select-Object -First 1
+
+if (-not $askLlmFile) {
+    throw "Unable to locate askllm.exe in the publish output."
+}
+
+$filePath = $askLlmFile.FullName
+Write-Output "File found: $filePath, getting hash..."
+$hash = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
+Write-Output "Hash: $hash"
+
+$manifest = @{
+    version = $Version
+    architecture = @{
+        '64bit' = @{
+            url = "https://github.com/yetanotherchris/ask-llm/releases/download/v$Version/askllm.exe"
+            bin = @("askllm.exe")
+            hash = $hash
+        }
+    }
+    homepage = "https://github.com/yetanotherchris/ask-llm"
+    license = "MIT License"
+    description = "Ask any large language model from your terminal via OpenAI-compatible APIs."
+}
+
+Write-Output "Creating ask-llm.json for version $Version..."
+$manifest | ConvertTo-Json -Depth 5 | Out-File -FilePath "ask-llm.json" -Encoding utf8


### PR DESCRIPTION
## Summary
- add the tiny-city release workflow adapted for ask-llm builds and releases
- include GitVersion configuration plus scoop manifest/update script for Windows packaging
- rewrite the README with detailed download, configuration, and usage instructions
- normalize release assets, scoop manifest, and documentation to use the lowercase askllm binary name and updated usage examples

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d70d8619fc832fad7524523eeed799