### PR TITLE
Add Spectre status indicator while requesting LLM responses

### DIFF
--- a/src/AskLlm/Commands/AskCommand.cs
+++ b/src/AskLlm/Commands/AskCommand.cs
@@ -89,7 +89,19 @@ public class AskCommand : AsyncCommand<AskCommandSettings>
 
         try
         {
-            var response = await _chatEndpointService.SendChatRequestAsync(request, CancellationToken.None);
+            ChatResponse? response = null;
+
+            await _console.Status()
+                .StartAsync("Requesting response from the LLM...", async _ =>
+                {
+                    response = await _chatEndpointService.SendChatRequestAsync(request, CancellationToken.None);
+                });
+
+            if (response is null)
+            {
+                RenderError("The LLM response could not be retrieved.");
+                return 1;
+            }
 
             if (!response.Success)
             {


### PR DESCRIPTION
## Summary
- display a Spectre.Console status while the chat request is sent to the LLM
- ensure errors are surfaced if the response is unavailable after the status completes

## Testing
- dotnet test *(fails: roll-forward Major "/root/.nuget/packages/gitversion.msbuild/6.2.0/tools/net8.0/gitversion.dll" "/workspace/ask-llm/src/AskLlm" -output file -outputfile "obj/gitversion.json"" exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68d73499459c832f8f6c9a5d24959f32