### PR TITLE
Expand provider examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ ask-llm reads its configuration from environment variables:
 - `ASKLLM_API_KEY` (required): API key used to authenticate with your OpenAI-compatible endpoint.
 - `ASKLLM_API_ENDPOINT` (optional): Override the default endpoint (`https://openrouter.ai/api/v1`).
 
+See [Provider Examples](providers.md) for common OpenAI-compatible providers, their base URLs, and how to create API keys.
+
 ### Setting environment variables
 
 PowerShell:
@@ -73,7 +75,7 @@ If you clone the source (requires [.NET 9](https://dotnet.microsoft.com/en-us/do
 
 ```bash
 dotnet restore
-dotnet run --project src/AskLlm/AskLlm.csproj -- --model gpt-4o-mini "Hello there"
+dotnet run --project AskLlm.csproj -- --model gpt-4o-mini "Hello there"
 ```
 
 ## Development

--- a/providers.md
+++ b/providers.md
@@ -1,0 +1,46 @@
+# Provider Examples
+
+## Anthropic (Claude)
+- **OpenAI-compatible API URL:** `https://api.anthropic.com/v1/messages`
+- **Notes:** Claude's native Messages API requires Anthropic-specific headers. For strict OpenAI format compatibility, route through an intermediary such as OpenRouter or Fireworks when selecting a Claude model.
+- **API key documentation:** [Anthropic Docs - Create an API key](https://docs.anthropic.com/en/api/getting-started)
+
+## Azure OpenAI Service
+- **OpenAI-compatible API URL:** `https://{your-resource-name}.openai.azure.com/openai`
+- **API key documentation:** [Microsoft Learn - Create an Azure OpenAI resource](https://learn.microsoft.com/azure/ai-services/openai/how-to/create-resource)
+
+## DeepInfra
+- **OpenAI-compatible API URL:** `https://api.deepinfra.com/v1/openai`
+- **API key documentation:** [DeepInfra Docs - Authentication](https://deepinfra.com/docs/getting-started#authentication)
+
+## Fireworks AI
+- **OpenAI-compatible API URL:** `https://api.fireworks.ai/inference/v1`
+- **API key documentation:** [Fireworks Docs - Generate an API key](https://docs.fireworks.ai/docs/getting-started#generate-an-api-key)
+
+## Google Gemini
+- **OpenAI-compatible API URL:** `https://generativelanguage.googleapis.com/v1beta/openai`
+- **API key documentation:** [Google AI Gemini Docs - Create an API key](https://ai.google.dev/gemini-api/docs/get-started#api-key)
+
+## Groq
+- **OpenAI-compatible API URL:** `https://api.groq.com/openai/v1`
+- **API key documentation:** [Groq Console Docs - API Keys](https://console.groq.com/docs/api-keys)
+
+## Mistral AI
+- **OpenAI-compatible API URL:** `https://api.mistral.ai/v1`
+- **API key documentation:** [Mistral Docs - Retrieve your API key](https://docs.mistral.ai/getting-started/quickstart/#retrieve-your-api-key)
+
+## OpenAI
+- **OpenAI-compatible API URL:** `https://api.openai.com/v1`
+- **API key documentation:** [OpenAI Platform - API Keys](https://platform.openai.com/account/api-keys)
+
+## OpenRouter
+- **OpenAI-compatible API URL:** `https://openrouter.ai/api/v1`
+- **API key documentation:** [OpenRouter Docs - Authentication](https://openrouter.ai/docs#authentication)
+
+## Together AI
+- **OpenAI-compatible API URL:** `https://api.together.xyz/v1`
+- **API key documentation:** [Together AI Docs - Obtain an API key](https://docs.together.ai/docs/quickstart#obtain-an-api-key)
+
+## xAI (Grok)
+- **OpenAI-compatible API URL:** `https://api.x.ai/v1`
+- **API key documentation:** [xAI Docs - Generate an API key](https://docs.x.ai/docs/getting-started#generate-your-api-key)


### PR DESCRIPTION
## Summary
- add a Provider Examples guide that lists OpenAI-compatible API endpoints and API key docs for popular providers
- expand the guide with additional providers including Anthropic (Claude), Google Gemini, and xAI (Grok)

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a247a388832fa1f60ec02d2c8cb7