### PR TITLE
Add color option to ask command settings

### DIFF
--- a/Commands/AskCommand.cs
+++ b/Commands/AskCommand.cs
@@ -17,6 +17,8 @@ public sealed class AskCommandSettings
 
     public string? OutputFile { get; set; }
 
+    public string? Color { get; set; }
+
     public bool StoreDefaults { get; set; }
 
     public CommandValidationResult Validate()

--- a/Program.cs
+++ b/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.CommandLine;
 using System.Reflection;
+using Spectre.Console;
 
 namespace AskLlm;
 


### PR DESCRIPTION
## Summary
- add a nullable Color option to AskCommandSettings so color defaults can be persisted and validated
- include the Spectre.Console using in Program to resolve IAnsiConsole registrations

## Testing
- dotnet build askllm.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7c9202598832f823e1f16dfe4998f