### PR TITLE
Replace Spectre console usage with Crayon output

### DIFF
--- a/AskLlm.csproj
+++ b/AskLlm.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
     <PackageReference Include="OpenAI" Version="2.5.0" />
-    <PackageReference Include="Spectre.Console" Version="0.51.1" />
+    <PackageReference Include="Crayon" Version="2.0.69" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.CommandLine;
 using System.Reflection;
-using Spectre.Console;
 
 namespace AskLlm;
 
@@ -47,7 +46,6 @@ public static class Program
         services.AddScoped<AskCommand>();
         services.AddSingleton<EnvironmentDefaultsMerger>();
         services.AddScoped<RootCommandFactory>();
-        services.AddSingleton<IAnsiConsole>(_ => AnsiConsole.Console);
 
         return services;
     }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ask-llm
-Ask any large language model from your terminal using an OpenAI-compatible API. The app is a .NET 9 console application that uses Spectre.Console to provide a friendly command-line experience.
+Ask any large language model from your terminal using an OpenAI-compatible API. The app is a .NET 9 console application that uses ANSI coloring via [Crayon](https://github.com/riezebosch/crayon) to provide a friendly command-line experience.
 
 ## Download
 

--- a/RootCommandFactory.cs
+++ b/RootCommandFactory.cs
@@ -1,5 +1,5 @@
+using System;
 using AskLlm.Commands;
-using Spectre.Console;
 using System.CommandLine;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
@@ -10,12 +10,10 @@ namespace AskLlm;
 public sealed class RootCommandFactory
 {
     private readonly AskCommand _askCommand;
-    private readonly IAnsiConsole _console;
 
-    public RootCommandFactory(AskCommand askCommand, IAnsiConsole console)
+    public RootCommandFactory(AskCommand askCommand)
     {
         _askCommand = askCommand;
-        _console = console;
     }
 
     public RootCommand Create(string applicationVersion)
@@ -36,6 +34,10 @@ public sealed class RootCommandFactory
         {
             ArgumentHelpName = "path"
         };
+        var colorOption = new Option<string?>("--color", "Optional console color name used when rendering responses.")
+        {
+            ArgumentHelpName = "color"
+        };
         var storeDefaultsOption = new Option<bool>("--store", "Store provided options (excluding --prompt) for future runs.");
         var versionOption = new Option<bool>("--version", "Show the application version.");
 
@@ -45,7 +47,8 @@ public sealed class RootCommandFactory
             promptOption,
             inputFileOption,
             outputFileOption,
-            storeDefaultsOption
+            storeDefaultsOption,
+            colorOption
         };
 
         rootCommand.AddAlias("ask");
@@ -56,7 +59,7 @@ public sealed class RootCommandFactory
             var showVersion = context.ParseResult.GetValueForOption(versionOption);
             if (showVersion)
             {
-                _console.MarkupLine($"askllm v{Markup.Escape(applicationVersion)}");
+                context.Console.Out.Write($"askllm v{applicationVersion}{Environment.NewLine}");
                 context.ExitCode = 0;
                 return;
             }
@@ -75,6 +78,7 @@ public sealed class RootCommandFactory
                 Prompt = context.ParseResult.GetValueForOption(promptOption) ?? string.Empty,
                 InputFile = context.ParseResult.GetValueForOption(inputFileOption),
                 OutputFile = context.ParseResult.GetValueForOption(outputFileOption),
+                Color = context.ParseResult.GetValueForOption(colorOption),
                 StoreDefaults = context.ParseResult.GetValueForOption(storeDefaultsOption)
             };
 

--- a/specification.md
+++ b/specification.md
@@ -1,7 +1,7 @@
 # AskLLM Application Specification
 
 ## Project Overview
-Create a C# .NET 9 console application named "askllm" that queries Large Language Models via OpenAI-compatible APIs using dependency injection and displays responses using Spectre.Console.
+Create a C# .NET 9 console application named "askllm" that queries Large Language Models via OpenAI-compatible APIs using dependency injection and displays responses using ANSI-colored console output.
 
 ## Technical Requirements
 
@@ -12,9 +12,8 @@ Create a C# .NET 9 console application named "askllm" that queries Large Languag
 - **Namespace**: `AskLlm`
 
 ### Required NuGet Packages
-- Spectre.Console
+- Crayon
 - OpenAI (from https://github.com/openai/openai-dotnet)
-- Spectre.Console.Cli
 - Microsoft.Extensions.DependencyInjection
 - Microsoft.Extensions.Logging
 - Microsoft.Extensions.Configuration
@@ -61,7 +60,6 @@ askllm <query> --model <model_name>
 ### Dependency Injection
 - Use Microsoft.Extensions.DependencyInjection
 - Configure services using extension methods
-- Use custom TypeRegistrar and TypeResolver for Spectre.Console.Cli integration
 - Inject services into commands via constructor injection
 
 ### Service Layer
@@ -98,9 +96,9 @@ askllm <query> --model <model_name>
 - Service unavailable
 
 ### Output Formatting
-- Use Spectre.Console for all output
-- Success responses with panels or markup for clean formatting
-- Error messages with red styling
+- Use ANSI escape sequences via Crayon for colored output
+- Success responses should clearly label the model alongside the generated content
+- Error messages should be displayed in red styling
 - Include model information in successful responses
 
 ## Unit Testing Requirements


### PR DESCRIPTION
## Summary
- remove the Spectre.Console dependency and DI registrations, replacing it with the Crayon package
- rework AskCommand to color console output via Crayon and validate ConsoleColor values from the --color option
- update documentation to reference Crayon-based ANSI output instead of Spectre.Console

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d7d66c7d90832fb31437b0c9b210dc