### PR TITLE
Upgrade to .NET 10.0 and integrate GitVersion for versioning

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore dependencies
         run: dotnet restore
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: bin/Release/net9.0/${{ matrix.rid }}/publish/${{ matrix.file_name }}
+          path: bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.file_name }}
           if-no-files-found: error
 
   release:

--- a/AskLlm.csproj
+++ b/AskLlm.csproj
@@ -2,19 +2,22 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>AskLlm</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <SelfContained>true</SelfContained>
+    <PackageId>askllm</PackageId>
+    <Authors>C.Small</Authors>
+    <Description>A command line tool for asking any large language model from your terminal via OpenAI-compatible APIs</Description>
     <AssemblyName>askllm</AssemblyName>
+
+    <!-- AOT -->
     <PublishAot>true</PublishAot>
     <PublishReadyToRun>false</PublishReadyToRun>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
     <OptimizationPreference>Speed</OptimizationPreference>
-    <Version>0.1.0</Version>
-    <FileVersion>0.1.0.0</FileVersion>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <InformationalVersion>0.1.0-local</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +28,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
     <PackageReference Include="OpenAI" Version="2.5.0" />
     <PackageReference Include="Crayon" Version="2.0.69" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
This PR upgrades the project to .NET 10.0 and implements automated versioning using GitVersion, removing hardcoded version numbers from the project file.

## Key Changes
- **Framework upgrade**: Updated target framework from `net9.0` to `net10.0` across project file and CI/CD workflows
- **Versioning automation**: Replaced hardcoded version properties (`Version`, `FileVersion`, `AssemblyVersion`, `InformationalVersion`) with GitVersion.MsBuild integration for dynamic version management
- **Project metadata**: Added package metadata including `RootNamespace`, `PackageId`, `Authors`, and `Description` for better package publishing
- **Build configuration**: Consolidated and clarified AOT (Ahead-of-Time) compilation settings with explicit comments
- **CI/CD updates**: Updated GitHub Actions workflow to use .NET 10.0.x and reference the correct output path (`net10.0` instead of `net9.0`)

## Implementation Details
- GitVersion.MsBuild is configured with appropriate asset inclusion for build-time version generation
- Self-contained deployment is explicitly enabled for both runtime and AOT scenarios
- The project maintains its focus on AOT compilation with `PublishAot=true` and optimized for speed

https://claude.ai/code/session_013PpesTcPQ7rcsZfB9wCB4x