### PR TITLE
Skill - env vars and Claude Desktop installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ These examples use [www.openrouter.ai's model names](https://openrouter.ai/model
 
 ```bash
 # Powershell (use control panel/edit environmental variables to persist)
-# $env:ASK_LLM_API_KEY="sk-123"
+# $env:ASKLLM_API_KEY="sk-123"
 
 # Bash
 # Persist the env var in ~/.bashrc 
-export ASK_LLM_API_KEY='sk-123'
+export ASKLLM_API_KEY='sk-123'
 
 askllm --model "openrouter/auto" --prompt "Write a haiku about dotnet"
 askllm --model "deepseek/deepseek-r1-0528:free" --prompt "What is love?" --store
@@ -42,12 +42,13 @@ $env:ASKLLM_API_ENDPOINT="http://localhost:3000/api/"
 askllm --model "gemma3:latest" --prompt "Tell me about the moon in 1 sentence"
 ```
 
-## Download
+## Installation
 
-[![GitHub Release](https://img.shields.io/github/v/release/yetanotherchris/ask-llm?logo=github&sort=semver)](https://github.com/yetanotherchris/ask-llm/releases/latest)  
-*Note: you do not need .NET installed for askllm to work, it is standalone.*
+[![GitHub Release](https://img.shields.io/github/v/release/yetanotherchris/ask-llm?logo=github&sort=semver)](https://github.com/yetanotherchris/ask-llm/releases/latest)
 
-**Package managers**
+`askllm` is a standalone binary — it is **not** an NPM package and does not require Node.js, .NET, or any other runtime to be installed. Just download the binary for your platform and run it.
+
+### Package managers
 
 Scoop on Windows:
 ```powershell
@@ -61,33 +62,38 @@ brew tap yetanotherchris/ask-llm https://github.com/yetanotherchris/ask-llm
 brew install ask-llm
 ```
 
-**Via your terminal**
+### Direct download
 
+**Windows (PowerShell):**
 ```powershell
 Invoke-WebRequest -Uri "https://github.com/yetanotherchris/ask-llm/releases/latest/download/askllm.exe" -OutFile "askllm.exe"
 ```
+
+**Linux/macOS (wget):**
 ```bash
 wget -O askllm "https://github.com/yetanotherchris/ask-llm/releases/latest/download/askllm"
 chmod +x askllm
 ```
+
+**Linux/macOS (curl):**
 ```bash
 curl -L "https://github.com/yetanotherchris/ask-llm/releases/latest/download/askllm" -o askllm
 chmod +x askllm
 ```
 
-And finally the [Github Releases page](https://github.com/yetanotherchris/ask-llm/releases).
+Or download directly from the [GitHub Releases page](https://github.com/yetanotherchris/ask-llm/releases).
 
 
 ## Configuration
 
 ask-llm reads its configuration from environment variables:
 
-- `ASK_LLM_API_KEY` (required): API key used to authenticate with your OpenAI-compatible endpoint.
-- `ASK_LLM_API_ENDPOINT` (optional): Override the default endpoint (`https://openrouter.ai/api/v1`).
+- `ASKLLM_API_KEY` (required): API key used to authenticate with your OpenAI-compatible endpoint.
+- `ASKLLM_API_ENDPOINT` (optional): Override the default endpoint (`https://openrouter.ai/api/v1`).
 
 See the [provider examples](providers.md) for common OpenAI-compatible providers, their base URLs, and how to create API keys.
 
-`ASK_LLM_DEFAULT` is used to store default command line options, but not the prompt. On Linux and Mac this will be written to your bash profile.
+`ASKLLM_DEFAULTS` is used to store default command line options, but not the prompt. On Linux and Mac this will be written to your bash profile.
 
 ## Usage
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,11 +17,43 @@ Use this skill when you need to:
 - Compare responses across different models
 - Store default model settings for repeated use
 
+## Installation
+
+`askllm` is a standalone binary — it is **not** an NPM/Node.js package. It does not require any runtime. Install via Homebrew, Scoop, or download the binary from [GitHub Releases](https://github.com/yetanotherchris/ask-llm/releases/latest).
+
+```bash
+# macOS/Linux
+brew tap yetanotherchris/ask-llm https://github.com/yetanotherchris/ask-llm
+brew install ask-llm
+```
+
+If `askllm` is not found on the PATH, check if it is installed first before trying to use it.
+
 ## Prerequisites
 
 The environment variable `ASKLLM_API_KEY` must be set with a valid API key for the LLM provider. If it is not set, inform the user they need to configure it first.
 
 Optionally, `ASKLLM_API_ENDPOINT` can be set to a custom API endpoint. It defaults to OpenRouter (`https://openrouter.ai/api/v1`).
+
+### Claude Desktop environment variable access
+
+Claude Desktop runs commands in a sandboxed shell that does not load the user's shell profile (`~/.bashrc`, `~/.zshrc`, etc.), so environment variables set there will not be available.
+
+**Windows (Claude Desktop):** Place a `.env` file at `C:\Users\<yourUsername>\Documents\Claude\.env` containing:
+```
+ASKLLM_API_KEY=sk-your-key-here
+```
+
+**macOS/Linux (Claude Desktop or sandboxed shells):** Before running `askllm`, source the user's shell profile to load the environment variable:
+```bash
+source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null || true
+askllm --model "openrouter/auto" --prompt "hello"
+```
+
+Alternatively, if the env var is still not set after sourcing, grep for it in the user's profile:
+```bash
+eval "$(grep 'ASKLLM_API_KEY' ~/.bashrc ~/.zshrc 2>/dev/null | head -1)"
+```
 
 ## Usage
 


### PR DESCRIPTION
## Summary
This PR standardizes environment variable naming conventions and significantly expands installation and configuration documentation for better clarity and user experience.

## Key Changes

**Environment Variable Standardization:**
- Renamed `ASK_LLM_API_KEY` to `ASKLLM_API_KEY` throughout documentation
- Renamed `ASK_LLM_API_ENDPOINT` to `ASKLLM_API_ENDPOINT` for consistency
- Renamed `ASK_LLM_DEFAULT` to `ASKLLM_DEFAULTS` to match the new naming pattern

**Installation Documentation (README.md):**
- Reorganized "Download" section into "Installation" with clearer structure
- Added explicit clarification that `askllm` is a standalone binary requiring no runtime dependencies (.NET, Node.js, etc.)
- Reorganized package manager instructions with subsection headers
- Added platform-specific labels for direct download methods (Windows PowerShell, Linux/macOS wget, Linux/macOS curl)
- Improved formatting and readability of installation instructions

**SKILL.md Enhancements:**
- Added new "Installation" section with Homebrew installation instructions
- Added comprehensive "Claude Desktop environment variable access" subsection covering:
  - Windows: `.env` file placement at `C:\Users\<yourUsername>\Documents\Claude\.env`
  - macOS/Linux: Shell profile sourcing workarounds for sandboxed environments
  - Alternative grep-based approach for extracting environment variables
- Updated Prerequisites section with new Claude Desktop-specific guidance

## Notable Details
- All documentation now uses consistent `ASKLLM_*` naming convention
- Installation instructions now clearly distinguish between package managers and direct downloads
- Added specific guidance for Claude Desktop users dealing with sandboxed shell environments
- Improved user experience by addressing common setup issues upfront

https://claude.ai/code/session_0143CPcrefzF3VnAT3fu5Kmn