### PR TITLE
Improve API key setup documentation for sandboxed environments

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -35,9 +35,27 @@ The environment variable `ASKLLM_API_KEY` must be set with a valid API key for t
 
 Optionally, `ASKLLM_API_ENDPOINT` can be set to a custom API endpoint. It defaults to OpenRouter (`https://openrouter.ai/api/v1`).
 
-### Setting the API key in sandboxed environments (Claude Desktop / Claude Web)
+### Claude Desktop
 
-Claude Desktop and Claude Web run commands in a sandboxed shell that does **not** have access to the user's shell profile (`~/.bashrc`, `~/.zshrc`, etc.), so environment variables set there will not be available.
+Claude Desktop runs commands in a sandboxed shell that does **not** load the user's shell profile (`~/.bashrc`, `~/.zshrc`, etc.). However, it can read the local filesystem.
+
+Users can store the API key persistently in their Claude Code user settings at `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ASKLLM_API_KEY": "sk-your-key-here"
+  }
+}
+```
+
+This file is local to the user's machine, not committed to git, and is loaded automatically by Claude Code. Once configured, the key is available in every session.
+
+If `ASKLLM_API_KEY` is not set, tell the user to add it to `~/.claude/settings.json` as shown above.
+
+### Claude Web
+
+Claude Web runs in a remote sandbox with no access to the user's local filesystem. The API key cannot be persisted between sessions.
 
 Before running `askllm`, check if `ASKLLM_API_KEY` is set:
 
@@ -50,18 +68,6 @@ If it is empty, **ask the user to provide their API key**. Once they provide it,
 ```bash
 export ASKLLM_API_KEY="<key provided by the user>"
 ```
-
-Tell the user they can avoid being asked each session by adding the key to their Claude Code user settings at `~/.claude/settings.json`:
-
-```json
-{
-  "env": {
-    "ASKLLM_API_KEY": "sk-your-key-here"
-  }
-}
-```
-
-This file is local to the user's machine, not committed to git, and is loaded automatically by Claude Code.
 
 ## Usage
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,32 +31,37 @@ If `askllm` is not found on the PATH, check if it is installed first before tryi
 
 ## Prerequisites
 
-The environment variable `ASKLLM_API_KEY` must be set with a valid API key for the LLM provider. If it is not set, inform the user they need to configure it first.
+The environment variable `ASKLLM_API_KEY` must be set with a valid API key for the LLM provider.
 
 Optionally, `ASKLLM_API_ENDPOINT` can be set to a custom API endpoint. It defaults to OpenRouter (`https://openrouter.ai/api/v1`).
 
-### Claude Desktop environment variable access
+### Setting the API key in sandboxed environments (Claude Desktop / Claude Web)
 
-Claude Desktop runs commands in a sandboxed shell that does not load the user's shell profile (`~/.bashrc`, `~/.zshrc`, etc.), so environment variables set there will not be available.
+Claude Desktop and Claude Web run commands in a sandboxed shell that does **not** have access to the user's shell profile (`~/.bashrc`, `~/.zshrc`, etc.), so environment variables set there will not be available.
 
-**Windows (Claude Desktop):** Place a `.env` file at `C:\Users\<yourUsername>\Documents\Claude\.env` containing:
-```
-ASKLLM_API_KEY=sk-your-key-here
-```
+Before running `askllm`, check if `ASKLLM_API_KEY` is set:
 
-This is the directory that Claude Cowork has accses to.  
-The virtiofs sandbox does not expose the Documents folder via bash, so use the `mcp__filesystem__read_file` tool to read this file.
-
-**macOS/Linux (Claude Desktop or sandboxed shells):** Before running `askllm`, source the user's shell profile to load the environment variable:
 ```bash
-source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null || true
-askllm --model "openrouter/auto" --prompt "hello"
+echo "$ASKLLM_API_KEY"
 ```
 
-Alternatively, if the env var is still not set after sourcing, grep for it in the user's profile:
+If it is empty, **ask the user to provide their API key**. Once they provide it, export it for the session:
+
 ```bash
-eval "$(grep 'ASKLLM_API_KEY' ~/.bashrc ~/.zshrc 2>/dev/null | head -1)"
+export ASKLLM_API_KEY="<key provided by the user>"
 ```
+
+Tell the user they can avoid being asked each session by adding the key to their Claude Code user settings at `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ASKLLM_API_KEY": "sk-your-key-here"
+  }
+}
+```
+
+This file is local to the user's machine, not committed to git, and is loaded automatically by Claude Code.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
Updated the SKILL.md documentation to provide clearer and more practical guidance for setting up the `ASKLLM_API_KEY` environment variable in sandboxed environments like Claude Desktop and Claude Web.

## Key Changes
- **Simplified prerequisites section**: Removed conditional language about informing users, making the requirement statement more direct
- **Unified sandboxed environment guidance**: Combined Claude Desktop and Claude Web into a single section with a more descriptive heading
- **Improved setup instructions**: Replaced complex shell sourcing workarounds with a straightforward approach:
  - Check if the API key is set using `echo "$ASKLLM_API_KEY"`
  - Ask the user to provide their key if not set
  - Export it for the current session using `export`
- **Added persistent configuration method**: Documented the recommended way to persist the API key across sessions via `~/.claude/settings.json` in Claude Code user settings
- **Removed platform-specific workarounds**: Eliminated Windows-specific `.env` file instructions and macOS/Linux shell sourcing hacks in favor of the unified settings.json approach
- **Added clarification**: Noted that settings.json is local to the user's machine and not committed to git

## Implementation Details
The new approach is more user-friendly and maintainable by:
1. Providing a simple verification step before attempting to use `askllm`
2. Offering an immediate session-based solution via `export`
3. Directing users to the proper persistent configuration location that Claude Code recognizes
4. Removing technical complexity around sandbox filesystem access and shell profile loading

https://claude.ai/code/session_01FtGf6Nk87JUDKrmJ5zAQxG