### PR TITLE
Improve ASKLLM_API_KEY setup flow with interactive configuration

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -51,7 +51,14 @@ Users can store the API key persistently in their Claude Code user settings at `
 
 This file is local to the user's machine, not committed to git, and is loaded automatically by Claude Code. Once configured, the key is available in every session.
 
-If `ASKLLM_API_KEY` is not set, tell the user to add it to `~/.claude/settings.json` as shown above.
+If `ASKLLM_API_KEY` is not set:
+
+1. Ask the user to provide their API key.
+2. If they provide a key, write it to `~/.claude/settings.json` using the Edit or Write tool (do **not** use bash — the shell is sandboxed). Read the file first; if it already exists, merge the key into the existing `env` object. If the file does not exist, create it with the structure shown above.
+3. After writing, also export the key for the current session so it is available immediately:
+   ```bash
+   export ASKLLM_API_KEY="<key>"
+   ```
 
 ### Claude Web
 


### PR DESCRIPTION
## Summary
Updated the SKILL.md documentation to provide clearer guidance on handling missing `ASKLLM_API_KEY` configuration, including an interactive setup flow that allows users to provide their API key and have it automatically persisted.

## Key Changes
- Replaced simple instruction to "add key to settings" with a three-step interactive process:
  1. Prompt user to provide their API key
  2. Persist the key to `~/.claude/settings.json` using the Edit/Write tool (avoiding shell execution)
  3. Export the key for immediate availability in the current session
- Added explicit guidance on file handling: read existing file, merge into existing `env` object if present, or create new file with proper structure
- Clarified that bash should not be used for file operations due to sandbox restrictions
- Included example bash export command for session-level key availability

## Implementation Details
- The approach prioritizes user experience by automating persistence rather than requiring manual file editing
- File operations use Claude Code's Edit/Write tools instead of shell commands to respect sandbox constraints
- The solution handles both new and existing configuration files gracefully

https://claude.ai/code/session_01LEV2heMh32wyzg3axtE9a2