### PR TITLE
Add Windows support for Claude settings file path

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -58,8 +58,8 @@ If `ASKLLM_API_KEY` is not set:
 
 1. Ask the user to provide their API key.
 2. **On macOS / Linux:** If they provide a key, write it to `~/.claude/settings.json` using the Edit or Write tool (do **not** use bash — the shell is sandboxed). Read the file first; if it already exists, merge the key into the existing `env` object. If the file does not exist, create it with the structure shown above.
-3. **On Windows:** Claude Desktop's filesystem access is sandboxed and cannot reach the settings file. Ask the user to manually add the key to their settings file at `%APPDATA%\claude\settings.json`. Provide the JSON snippet above so they can copy it.
-4. After writing (or while the user edits the file manually), also export the key for the current session so it is available immediately:
+3. **On Windows:** Claude Desktop's filesystem access is sandboxed and cannot reach the settings file. Tell the user to add the key to their settings file at `%APPDATA%\claude\settings.json` for future sessions (using the JSON snippet above), then ask them to paste the key in chat so you can export it for the current session.
+4. Export the key for the current session so it is available immediately:
    ```bash
    export ASKLLM_API_KEY="<key>"
    ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,7 +39,10 @@ Optionally, `ASKLLM_API_ENDPOINT` can be set to a custom API endpoint. It defaul
 
 Claude Desktop runs commands in a sandboxed shell that does **not** load the user's shell profile (`~/.bashrc`, `~/.zshrc`, etc.). However, it can read the local filesystem.
 
-Users can store the API key persistently in their Claude Code user settings at `~/.claude/settings.json`:
+Users can store the API key persistently in their Claude Code user settings file:
+
+- **macOS / Linux:** `~/.claude/settings.json`
+- **Windows:** `%APPDATA%\claude\settings.json` (typically `C:\Users\<username>\AppData\Roaming\claude\settings.json`)
 
 ```json
 {
@@ -54,8 +57,9 @@ This file is local to the user's machine, not committed to git, and is loaded au
 If `ASKLLM_API_KEY` is not set:
 
 1. Ask the user to provide their API key.
-2. If they provide a key, write it to `~/.claude/settings.json` using the Edit or Write tool (do **not** use bash — the shell is sandboxed). Read the file first; if it already exists, merge the key into the existing `env` object. If the file does not exist, create it with the structure shown above.
-3. After writing, also export the key for the current session so it is available immediately:
+2. **On macOS / Linux:** If they provide a key, write it to `~/.claude/settings.json` using the Edit or Write tool (do **not** use bash — the shell is sandboxed). Read the file first; if it already exists, merge the key into the existing `env` object. If the file does not exist, create it with the structure shown above.
+3. **On Windows:** Claude Desktop's filesystem access is sandboxed and cannot reach the settings file. Ask the user to manually add the key to their settings file at `%APPDATA%\claude\settings.json`. Provide the JSON snippet above so they can copy it.
+4. After writing (or while the user edits the file manually), also export the key for the current session so it is available immediately:
    ```bash
    export ASKLLM_API_KEY="<key>"
    ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -58,7 +58,7 @@ If `ASKLLM_API_KEY` is not set:
 
 1. Ask the user to provide their API key.
 2. **On macOS / Linux:** If they provide a key, write it to `~/.claude/settings.json` using the Edit or Write tool (do **not** use bash — the shell is sandboxed). Read the file first; if it already exists, merge the key into the existing `env` object. If the file does not exist, create it with the structure shown above.
-3. **On Windows:** Claude Desktop's filesystem access is sandboxed and cannot reach the settings file. Tell the user to add the key to their settings file at `%APPDATA%\claude\settings.json` for future sessions (using the JSON snippet above), then ask them to paste the key in chat so you can export it for the current session.
+3. **On Windows:** Claude Desktop's filesystem access is sandboxed and cannot reach the settings file. Ask the user to paste the key in chat so you can export it for the current session. Also give them instructions on how to add it to their settings file at `%APPDATA%\claude\settings.json` so it persists across sessions — show them the JSON snippet above and explain how to create the file and folder if they don't exist.
 4. Export the key for the current session so it is available immediately:
    ```bash
    export ASKLLM_API_KEY="<key>"


### PR DESCRIPTION
## Summary
Updated documentation to clarify API key storage paths across different operating systems and provide Windows-specific instructions for persisting API keys.

## Key Changes
- **Path clarification:** Replaced generic `~/.claude/settings.json` reference with platform-specific paths:
  - macOS / Linux: `~/.claude/settings.json`
  - Windows: `%APPDATA%\claude\settings.json` (typically `C:\Users\<username>\AppData\Roaming\claude\settings.json`)

- **Windows-specific workflow:** Added separate instructions for Windows users since Claude Desktop's sandboxed filesystem access cannot reach the settings file:
  - Users should provide their API key via chat
  - Instructions include manual steps to add the key to their settings file
  - Includes JSON snippet and guidance on creating the file/folder structure

- **Improved step numbering:** Renumbered workflow steps to clearly distinguish between platform-specific steps (2-3) and the common session export step (4)

## Implementation Details
The changes maintain backward compatibility for macOS/Linux users while adding explicit Windows support with clear, actionable instructions for manual configuration.

https://claude.ai/code/session_01Wo1Ps9SDUqKFpsPWK7LDSP